### PR TITLE
Added nodecg-recentfollower, added missing -

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Bundles which provide alerts on an overlay.
 
 - [prime-alerts](https://github.com/ProbablePrime/prime-alerts) - Basic follow, sub and tip alerts that listen to nodecg-beam messages.
 
+## Widgets
+Bundles which provide some form of visual information on an overlay.
+
+- [nodecg-recentfollower](https://github.com/Allar/nodecg-recentfollower) - Displays the most recent follower from Beam or Twitch using [node-beam-service](https://github.com/Allar/nodecg-beam-service) and [node-twitch-service](https://github.com/Allar/nodecg-twitch-service).
+
 ## Service Integrations
 
 ### Twitch
@@ -46,7 +51,7 @@ Bundles which provide alerts on an overlay.
 
 ### Beam
 - [nodecg-beam](https://github.com/ProbablePrime/nodecg-beam) - Tracks Beam Follows, Subscriptions and Hosts and emits them as events for other bundles.
-- [nodecg-beam-service](https://github.com/Allar/nodecg-beam-service) Tracks Beam events using [constellation-client](https://github.com/StreamJar/Constellation) and provides Beam info via Replicants.
+- [nodecg-beam-service](https://github.com/Allar/nodecg-beam-service) - Tracks Beam events using [constellation-client](https://github.com/StreamJar/Constellation) and provides Beam info via Replicants.
 
 ## Utilities
 - [prime-manual-alerts](https://github.com/ProbablePrime/prime-manual-alerts) - Manual emits follow, subscription, host and tip events which prime-alerts can listen to.


### PR DESCRIPTION
nodecg-recentfollower is a simple 'recent follower' widget that uses nodecg-beam-service and nodecg-twitch-service to display the most recent follower.

Also added missing '-' in nodecg-beam-service description

https://github.com/Allar/nodecg-recentfollower