### PR TITLE
Add b2aExtraLife to Complete Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ NodeCG bundles (or suites of bundles) that provide an entire production system b
 
 - [sgdq16-layouts](https://github.com/GamesDoneQuick/sgdq16-layouts) - The on-stream graphics used during Summer Games Done Quick 2016.
 - [toth4-overlay](https://github.com/TipoftheHats/toth4-overlay) - The main broadcast assets for Tip of the Hats 2016.
+- [b2aExtraLife](https://github.com/cshomo11/b2aExtraLife) - A stream bundle created for Extra Life 2016. It will track donation totals, show a list of donors, and display games played and other messages.
 
 ## Alerts
 Bundles which provide alerts on an overlay.


### PR DESCRIPTION
This is a smaller system I created to use for my Extra Life 2016 stream.
It will connect to the Extra Life JSON to keep track of donation totals
and get a list of donors. The bundle can also keep a list of the games
you are playing to display in the lower third as well as any other
messages you might want to show. I think it could be a nice addition to the
list as lots of streamers over on the Extra Life forums are looking for overlays to track their donations. Thanks for your consideration!

[b2aExtraLife Bundle](https://github.com/cshomo11/b2aExtraLife)